### PR TITLE
Add default introductory code example

### DIFF
--- a/docs/SNIPPET.txt
+++ b/docs/SNIPPET.txt
@@ -1,0 +1,23 @@
+# Convert ascii string of binary digits to integer
+#
+# $a0 - input, pointer to null-terminated string of 1's and 0's
+# $v0 - output, integer form of binary string
+# $t0 - ascii value of the char pointed to
+# $t1 - integer value (0 or 1) of the char pointed to
+
+.globl binary_convert
+
+binary_convert:
+        li      $v0, 0                  # Reset accumulator to 0.
+
+loop:
+        lb      $t0, 0($a0)             # Load a character,
+        beq     $t0, $zero, end         # if it is null then return.
+        sll     $v0, $v0, 1             # Otherwise shift accumulator left,
+        addi    $t1, $t0, -48           # calculate the value of the character,
+        or      $v0, $v0, $t1           # and add that to the accumulator.
+        addi    $a0, $a0, 1             # Finally, increment the pointer
+        j       loop                    # and loop.
+
+end:
+        jr $ra


### PR DESCRIPTION
Instead of having logic for a fallback in the backend, we're choosing a
default for the snippet file.

For tracks that have core exercises, we pick the first core exercise.
For tracks without these, we pick the first exercise listed in the config.

Note that we're aiming for 10 lines and a max-width of 40 columns.
This solution has 23 lines and a max-width of 79, so we may want to adjust it.

See https://github.com/exercism/meta/issues/89