### PR TITLE
Remove unused exercise README insert

### DIFF
--- a/config/exercise_readme.go.tmpl
+++ b/config/exercise_readme.go.tmpl
@@ -4,9 +4,6 @@
 {{- with .Hints }}
 {{ . }}
 {{ end }}
-{{- with .TrackInsert }}
-{{ . }}
-{{ end }}
 {{- with .Spec.Credits -}}
 ## Source
 


### PR DESCRIPTION
This deletes the empty exercise README insert, and updates the exercise README template
to remove the reference to the insert.

If the track later requires some text to be repeated in all the exercise READMEs it can be
added directly to the config/exercise_readme.go.tmpl file.

See https://github.com/exercism/meta/issues/94