### PR TITLE
Add 'math' topic to relevant exercises in track config

### DIFF
--- a/config.json
+++ b/config.json
@@ -10,7 +10,9 @@
       "core": true,
       "unlocked_by": null,
       "difficulty": 1,
-      "topics": []
+      "topics": [
+        "math"
+      ]
     },
     {
       "slug": "octal",
@@ -18,7 +20,9 @@
       "core": false,
       "unlocked_by": "binary",
       "difficulty": 1,
-      "topics": []
+      "topics": [
+        "math"
+      ]
     },
     {
       "slug": "trinary",
@@ -26,7 +30,9 @@
       "core": false,
       "unlocked_by": "binary",
       "difficulty": 1,
-      "topics": []
+      "topics": [
+        "math"
+      ]
     },
     {
       "slug": "hexadecimal",
@@ -34,7 +40,9 @@
       "core": false,
       "unlocked_by": "binary",
       "difficulty": 1,
-      "topics": []
+      "topics": [
+        "math"
+      ]
     },
     {
       "slug": "leap",
@@ -50,7 +58,9 @@
       "core": true,
       "unlocked_by": null,
       "difficulty": 1,
-      "topics": []
+      "topics": [
+        "math"
+      ]
     },
     {
       "slug": "hamming",
@@ -114,7 +124,9 @@
       "core": true,
       "unlocked_by": null,
       "difficulty": 7,
-      "topics": []
+      "topics": [
+        "math"
+      ]
     }
   ]
 }


### PR DESCRIPTION
The new site lets people filter optional exercises by topic, and this
makes it easy for people to skip past them.

This is important since the math-y exercises are not key to learning
the language, and a lot of people find them intimidating and demotivating.

This updates any 'mathematics' topics to be 'math' since it's shorter
and won't get cropped in the UI.

It also removes the math topics for any exercises that are not in the
canonical math-y list.


exercism/exercism.io#4110