### PR TITLE
Bringing your track in line with the latest changes to Problem Specifications

### DIFF
--- a/exercises/practice/atbash-cipher/.meta/tests.toml
+++ b/exercises/practice/atbash-cipher/.meta/tests.toml
@@ -1,0 +1,52 @@
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
+
+[2f47ebe1-eab9-4d6b-b3c6-627562a31c77]
+description = "encode -> encode yes"
+
+[b4ffe781-ea81-4b74-b268-cc58ba21c739]
+description = "encode -> encode no"
+
+[10e48927-24ab-4c4d-9d3f-3067724ace00]
+description = "encode -> encode OMG"
+
+[d59b8bc3-509a-4a9a-834c-6f501b98750b]
+description = "encode -> encode spaces"
+
+[31d44b11-81b7-4a94-8b43-4af6a2449429]
+description = "encode -> encode mindblowingly"
+
+[d503361a-1433-48c0-aae0-d41b5baa33ff]
+description = "encode -> encode numbers"
+
+[79c8a2d5-0772-42d4-b41b-531d0b5da926]
+description = "encode -> encode deep thought"
+
+[9ca13d23-d32a-4967-a1fd-6100b8742bab]
+description = "encode -> encode all the letters"
+
+[bb50e087-7fdf-48e7-9223-284fe7e69851]
+description = "decode -> decode exercism"
+
+[ac021097-cd5d-4717-8907-b0814b9e292c]
+description = "decode -> decode a sentence"
+
+[18729de3-de74-49b8-b68c-025eaf77f851]
+description = "decode -> decode numbers"
+
+[0f30325f-f53b-415d-ad3e-a7a4f63de034]
+description = "decode -> decode all the letters"
+
+[39640287-30c6-4c8c-9bac-9d613d1a5674]
+description = "decode -> decode with too many spaces"
+
+[b34edf13-34c0-49b5-aa21-0768928000d5]
+description = "decode -> decode with no spaces"

--- a/exercises/practice/binary/.meta/tests.toml
+++ b/exercises/practice/binary/.meta/tests.toml
@@ -1,0 +1,55 @@
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
+
+[567fc71e-1013-4915-9285-bca0648c0844]
+description = "binary 0 is decimal 0"
+
+[c0824fb1-6a0a-4e9a-a262-c6c00af99fa8]
+description = "binary 1 is decimal 1"
+
+[4d2834fb-3cc3-4159-a8fd-da1098def8ed]
+description = "binary 10 is decimal 2"
+
+[b7b2b649-4a7c-4808-9eb9-caf00529bac6]
+description = "binary 11 is decimal 3"
+
+[de761aff-73cd-43c1-9e1f-0417f07b1e4a]
+description = "binary 100 is decimal 4"
+
+[7849a8f7-f4a1-4966-963e-503282d6814c]
+description = "binary 1001 is decimal 9"
+
+[836a101c-aecb-473b-ba78-962408dcda98]
+description = "binary 11010 is decimal 26"
+
+[1c6822a4-8584-438b-8dd4-40f0f0b66371]
+description = "binary 10001101000 is decimal 1128"
+
+[91ffe632-8374-4016-b1d1-d8400d9f940d]
+description = "binary ignores leading zeros"
+
+[44f7d8b1-ddc3-4751-8be3-700a538b421c]
+description = "2 is not a valid binary digit"
+
+[c263a24d-6870-420f-b783-628feefd7b6e]
+description = "a number containing a non-binary digit is invalid"
+
+[8d81305b-0502-4a07-bfba-051c5526d7f2]
+description = "a number with trailing non-binary characters is invalid"
+
+[a7f79b6b-039a-4d42-99b4-fcee56679f03]
+description = "a number with leading non-binary characters is invalid"
+
+[9e0ece9d-b8aa-46a0-a22b-3bed2e3f741e]
+description = "a number with internal non-binary characters is invalid"
+
+[46c8dd65-0c32-4273-bb0d-f2b111bccfbd]
+description = "a number and a word whitespace separated is invalid"

--- a/exercises/practice/difference-of-squares/.meta/tests.toml
+++ b/exercises/practice/difference-of-squares/.meta/tests.toml
@@ -1,0 +1,37 @@
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
+
+[e46c542b-31fc-4506-bcae-6b62b3268537]
+description = "Square the sum of the numbers up to the given number -> square of sum 1"
+
+[9b3f96cb-638d-41ee-99b7-b4f9c0622948]
+description = "Square the sum of the numbers up to the given number -> square of sum 5"
+
+[54ba043f-3c35-4d43-86ff-3a41625d5e86]
+description = "Square the sum of the numbers up to the given number -> square of sum 100"
+
+[01d84507-b03e-4238-9395-dd61d03074b5]
+description = "Sum the squares of the numbers up to the given number -> sum of squares 1"
+
+[c93900cd-8cc2-4ca4-917b-dd3027023499]
+description = "Sum the squares of the numbers up to the given number -> sum of squares 5"
+
+[94807386-73e4-4d9e-8dec-69eb135b19e4]
+description = "Sum the squares of the numbers up to the given number -> sum of squares 100"
+
+[44f72ae6-31a7-437f-858d-2c0837adabb6]
+description = "Subtract sum of squares from square of sums -> difference of squares 1"
+
+[005cb2bf-a0c8-46f3-ae25-924029f8b00b]
+description = "Subtract sum of squares from square of sums -> difference of squares 5"
+
+[b1bf19de-9a16-41c0-a62b-1f02ecc0b036]
+description = "Subtract sum of squares from square of sums -> difference of squares 100"

--- a/exercises/practice/hamming/.meta/tests.toml
+++ b/exercises/practice/hamming/.meta/tests.toml
@@ -1,0 +1,61 @@
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
+
+[f6dcb64f-03b0-4b60-81b1-3c9dbf47e887]
+description = "empty strands"
+
+[54681314-eee2-439a-9db0-b0636c656156]
+description = "single letter identical strands"
+
+[294479a3-a4c8-478f-8d63-6209815a827b]
+description = "single letter different strands"
+
+[9aed5f34-5693-4344-9b31-40c692fb5592]
+description = "long identical strands"
+
+[cd2273a5-c576-46c8-a52b-dee251c3e6e5]
+description = "long different strands"
+
+[919f8ef0-b767-4d1b-8516-6379d07fcb28]
+description = "disallow first strand longer"
+
+[b9228bb1-465f-4141-b40f-1f99812de5a8]
+description = "disallow first strand longer"
+reimplements = "919f8ef0-b767-4d1b-8516-6379d07fcb28"
+
+[8a2d4ed0-ead5-4fdd-924d-27c4cf56e60e]
+description = "disallow second strand longer"
+
+[dab38838-26bb-4fff-acbe-3b0a9bfeba2d]
+description = "disallow second strand longer"
+reimplements = "8a2d4ed0-ead5-4fdd-924d-27c4cf56e60e"
+
+[5dce058b-28d4-4ca7-aa64-adfe4e17784c]
+description = "disallow left empty strand"
+
+[db92e77e-7c72-499d-8fe6-9354d2bfd504]
+description = "disallow left empty strand"
+reimplements = "5dce058b-28d4-4ca7-aa64-adfe4e17784c"
+
+[b764d47c-83ff-4de2-ab10-6cfe4b15c0f3]
+description = "disallow empty first strand"
+reimplements = "db92e77e-7c72-499d-8fe6-9354d2bfd504"
+
+[38826d4b-16fb-4639-ac3e-ba027dec8b5f]
+description = "disallow right empty strand"
+
+[920cd6e3-18f4-4143-b6b8-74270bb8f8a3]
+description = "disallow right empty strand"
+reimplements = "38826d4b-16fb-4639-ac3e-ba027dec8b5f"
+
+[9ab9262f-3521-4191-81f5-0ed184a5aa89]
+description = "disallow empty second strand"
+reimplements = "920cd6e3-18f4-4143-b6b8-74270bb8f8a3"

--- a/exercises/practice/hello-world/.meta/tests.toml
+++ b/exercises/practice/hello-world/.meta/tests.toml
@@ -1,0 +1,13 @@
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
+
+[af9ffe10-dc13-42d8-a742-e7bdafac449d]
+description = "Say Hi!"

--- a/exercises/practice/isogram/.meta/tests.toml
+++ b/exercises/practice/isogram/.meta/tests.toml
@@ -1,0 +1,52 @@
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
+
+[a0e97d2d-669e-47c7-8134-518a1e2c4555]
+description = "empty string"
+
+[9a001b50-f194-4143-bc29-2af5ec1ef652]
+description = "isogram with only lower case characters"
+
+[8ddb0ca3-276e-4f8b-89da-d95d5bae78a4]
+description = "word with one duplicated character"
+
+[6450b333-cbc2-4b24-a723-0b459b34fe18]
+description = "word with one duplicated character from the end of the alphabet"
+
+[a15ff557-dd04-4764-99e7-02cc1a385863]
+description = "longest reported english isogram"
+
+[f1a7f6c7-a42f-4915-91d7-35b2ea11c92e]
+description = "word with duplicated character in mixed case"
+
+[14a4f3c1-3b47-4695-b645-53d328298942]
+description = "word with duplicated character in mixed case, lowercase first"
+
+[423b850c-7090-4a8a-b057-97f1cadd7c42]
+description = "hypothetical isogrammic word with hyphen"
+
+[93dbeaa0-3c5a-45c2-8b25-428b8eacd4f2]
+description = "hypothetical word with duplicated character following hyphen"
+
+[36b30e5c-173f-49c6-a515-93a3e825553f]
+description = "isogram with duplicated hyphen"
+
+[cdabafa0-c9f4-4c1f-b142-689c6ee17d93]
+description = "made-up name that is an isogram"
+
+[5fc61048-d74e-48fd-bc34-abfc21552d4d]
+description = "duplicated character in the middle"
+
+[310ac53d-8932-47bc-bbb4-b2b94f25a83e]
+description = "same first and last characters"
+
+[0d0b8644-0a1e-4a31-a432-2b3ee270d847]
+description = "word with duplicated character and with two hyphens"

--- a/exercises/practice/leap/.meta/tests.toml
+++ b/exercises/practice/leap/.meta/tests.toml
@@ -1,0 +1,37 @@
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
+
+[6466b30d-519c-438e-935d-388224ab5223]
+description = "year not divisible by 4 in common year"
+
+[ac227e82-ee82-4a09-9eb6-4f84331ffdb0]
+description = "year divisible by 2, not divisible by 4 in common year"
+
+[4fe9b84c-8e65-489e-970b-856d60b8b78e]
+description = "year divisible by 4, not divisible by 100 in leap year"
+
+[7fc6aed7-e63c-48f5-ae05-5fe182f60a5d]
+description = "year divisible by 4 and 5 is still a leap year"
+
+[78a7848f-9667-4192-ae53-87b30c9a02dd]
+description = "year divisible by 100, not divisible by 400 in common year"
+
+[9d70f938-537c-40a6-ba19-f50739ce8bac]
+description = "year divisible by 100 but not by 3 is still not a leap year"
+
+[42ee56ad-d3e6-48f1-8e3f-c84078d916fc]
+description = "year divisible by 400 is leap year"
+
+[57902c77-6fe9-40de-8302-587b5c27121e]
+description = "year divisible by 400 but not by 125 is still a leap year"
+
+[c30331f6-f9f6-4881-ad38-8ca8c12520c1]
+description = "year divisible by 200, not divisible by 400 in common year"

--- a/exercises/practice/nth-prime/.meta/tests.toml
+++ b/exercises/practice/nth-prime/.meta/tests.toml
@@ -1,0 +1,25 @@
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
+
+[75c65189-8aef-471a-81de-0a90c728160c]
+description = "first prime"
+
+[2c38804c-295f-4701-b728-56dea34fd1a0]
+description = "second prime"
+
+[56692534-781e-4e8c-b1f9-3e82c1640259]
+description = "sixth prime"
+
+[fce1e979-0edb-412d-93aa-2c744e8f50ff]
+description = "big prime"
+
+[bd0a9eae-6df7-485b-a144-80e13c7d55b2]
+description = "there is no zeroth prime"

--- a/exercises/practice/raindrops/.meta/tests.toml
+++ b/exercises/practice/raindrops/.meta/tests.toml
@@ -1,0 +1,64 @@
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
+
+[1575d549-e502-46d4-a8e1-6b7bec6123d8]
+description = "the sound for 1 is 1"
+
+[1f51a9f9-4895-4539-b182-d7b0a5ab2913]
+description = "the sound for 3 is Pling"
+
+[2d9bfae5-2b21-4bcd-9629-c8c0e388f3e0]
+description = "the sound for 5 is Plang"
+
+[d7e60daa-32ef-4c23-b688-2abff46c4806]
+description = "the sound for 7 is Plong"
+
+[6bb4947b-a724-430c-923f-f0dc3d62e56a]
+description = "the sound for 6 is Pling as it has a factor 3"
+
+[ce51e0e8-d9d4-446d-9949-96eac4458c2d]
+description = "2 to the power 3 does not make a raindrop sound as 3 is the exponent not the base"
+
+[0dd66175-e3e2-47fc-8750-d01739856671]
+description = "the sound for 9 is Pling as it has a factor 3"
+
+[022c44d3-2182-4471-95d7-c575af225c96]
+description = "the sound for 10 is Plang as it has a factor 5"
+
+[37ab74db-fed3-40ff-b7b9-04acdfea8edf]
+description = "the sound for 14 is Plong as it has a factor of 7"
+
+[31f92999-6afb-40ee-9aa4-6d15e3334d0f]
+description = "the sound for 15 is PlingPlang as it has factors 3 and 5"
+
+[ff9bb95d-6361-4602-be2c-653fe5239b54]
+description = "the sound for 21 is PlingPlong as it has factors 3 and 7"
+
+[d2e75317-b72e-40ab-8a64-6734a21dece1]
+description = "the sound for 25 is Plang as it has a factor 5"
+
+[a09c4c58-c662-4e32-97fe-f1501ef7125c]
+description = "the sound for 27 is Pling as it has a factor 3"
+
+[bdf061de-8564-4899-a843-14b48b722789]
+description = "the sound for 35 is PlangPlong as it has factors 5 and 7"
+
+[c4680bee-69ba-439d-99b5-70c5fd1a7a83]
+description = "the sound for 49 is Plong as it has a factor 7"
+
+[17f2bc9a-b65a-4d23-8ccd-266e8c271444]
+description = "the sound for 52 is 52"
+
+[e46677ed-ff1a-419f-a740-5c713d2830e4]
+description = "the sound for 105 is PlingPlangPlong as it has factors 3, 5 and 7"
+
+[13c6837a-0fcd-4b86-a0eb-20572f7deb0b]
+description = "the sound for 3125 is Plang as it has a factor 5"

--- a/exercises/practice/rna-transcription/.meta/tests.toml
+++ b/exercises/practice/rna-transcription/.meta/tests.toml
@@ -1,0 +1,28 @@
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
+
+[b4631f82-c98c-4a2f-90b3-c5c2b6c6f661]
+description = "Empty RNA sequence"
+
+[a9558a3c-318c-4240-9256-5d5ed47005a6]
+description = "RNA complement of cytosine is guanine"
+
+[6eedbb5c-12cb-4c8b-9f51-f8320b4dc2e7]
+description = "RNA complement of guanine is cytosine"
+
+[870bd3ec-8487-471d-8d9a-a25046488d3e]
+description = "RNA complement of thymine is adenine"
+
+[aade8964-02e1-4073-872f-42d3ffd74c5f]
+description = "RNA complement of adenine is uracil"
+
+[79ed2757-f018-4f47-a1d7-34a559392dbf]
+description = "RNA complement"

--- a/exercises/practice/scrabble-score/.meta/tests.toml
+++ b/exercises/practice/scrabble-score/.meta/tests.toml
@@ -1,0 +1,43 @@
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
+
+[f46cda29-1ca5-4ef2-bd45-388a767e3db2]
+description = "lowercase letter"
+
+[f7794b49-f13e-45d1-a933-4e48459b2201]
+description = "uppercase letter"
+
+[eaba9c76-f9fa-49c9-a1b0-d1ba3a5b31fa]
+description = "valuable letter"
+
+[f3c8c94e-bb48-4da2-b09f-e832e103151e]
+description = "short word"
+
+[71e3d8fa-900d-4548-930e-68e7067c4615]
+description = "short, valuable word"
+
+[d3088ad9-570c-4b51-8764-c75d5a430e99]
+description = "medium word"
+
+[fa20c572-ad86-400a-8511-64512daac352]
+description = "medium, valuable word"
+
+[9336f0ba-9c2b-4fa0-bd1c-2e2d328cf967]
+description = "long, mixed-case word"
+
+[1e34e2c3-e444-4ea7-b598-3c2b46fd2c10]
+description = "english-like word"
+
+[4efe3169-b3b6-4334-8bae-ff4ef24a7e4f]
+description = "empty input"
+
+[3b305c1c-f260-4e15-a5b5-cb7d3ea7c3d7]
+description = "entire alphabet available"

--- a/exercises/practice/triangle/.meta/tests.toml
+++ b/exercises/practice/triangle/.meta/tests.toml
@@ -1,0 +1,67 @@
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
+
+[8b2c43ac-7257-43f9-b552-7631a91988af]
+description = "equilateral triangle -> all sides are equal"
+
+[33eb6f87-0498-4ccf-9573-7f8c3ce92b7b]
+description = "equilateral triangle -> any side is unequal"
+
+[c6585b7d-a8c0-4ad8-8a34-e21d36f7ad87]
+description = "equilateral triangle -> no sides are equal"
+
+[16e8ceb0-eadb-46d1-b892-c50327479251]
+description = "equilateral triangle -> all zero sides is not a triangle"
+
+[3022f537-b8e5-4cc1-8f12-fd775827a00c]
+description = "equilateral triangle -> sides may be floats"
+
+[cbc612dc-d75a-4c1c-87fc-e2d5edd70b71]
+description = "isosceles triangle -> last two sides are equal"
+
+[e388ce93-f25e-4daf-b977-4b7ede992217]
+description = "isosceles triangle -> first two sides are equal"
+
+[d2080b79-4523-4c3f-9d42-2da6e81ab30f]
+description = "isosceles triangle -> first and last sides are equal"
+
+[8d71e185-2bd7-4841-b7e1-71689a5491d8]
+description = "isosceles triangle -> equilateral triangles are also isosceles"
+
+[840ed5f8-366f-43c5-ac69-8f05e6f10bbb]
+description = "isosceles triangle -> no sides are equal"
+
+[2eba0cfb-6c65-4c40-8146-30b608905eae]
+description = "isosceles triangle -> first triangle inequality violation"
+
+[278469cb-ac6b-41f0-81d4-66d9b828f8ac]
+description = "isosceles triangle -> second triangle inequality violation"
+
+[90efb0c7-72bb-4514-b320-3a3892e278ff]
+description = "isosceles triangle -> third triangle inequality violation"
+
+[adb4ee20-532f-43dc-8d31-e9271b7ef2bc]
+description = "isosceles triangle -> sides may be floats"
+
+[e8b5f09c-ec2e-47c1-abec-f35095733afb]
+description = "scalene triangle -> no sides are equal"
+
+[2510001f-b44d-4d18-9872-2303e7977dc1]
+description = "scalene triangle -> all sides are equal"
+
+[c6e15a92-90d9-4fb3-90a2-eef64f8d3e1e]
+description = "scalene triangle -> two sides are equal"
+
+[70ad5154-0033-48b7-af2c-b8d739cd9fdc]
+description = "scalene triangle -> may not violate triangle inequality"
+
+[26d9d59d-f8f1-40d3-ad58-ae4d54123d7d]
+description = "scalene triangle -> sides may be floats"

--- a/exercises/practice/trinary/.meta/tests.toml
+++ b/exercises/practice/trinary/.meta/tests.toml
@@ -1,0 +1,43 @@
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
+
+[a7a79a9e-5606-454c-9cdb-4f3c0ca46931]
+description = "trinary 1 is decimal 1"
+
+[39240078-13e2-4eb8-87c4-aeffa7d64130]
+description = "trinary 2 is decimal 2"
+
+[81900d67-7e07-4d41-a71e-86f1cd72ce1f]
+description = "trinary 10 is decimal 3"
+
+[7a8d5341-f88a-4c60-9048-4d5e017fa701]
+description = "trinary 11 is decimal 4"
+
+[6b3c37f6-d6b3-4575-85c0-19f48dd101af]
+description = "trinary 100 is decimal 9"
+
+[a210b2b8-d333-4e19-9e59-87cabdd2a0ba]
+description = "trinary 112 is decimal 14"
+
+[5ae03472-b942-42ce-ba00-e84a7dc86dd8]
+description = "trinary 222 is decimal 26"
+
+[d4fabf94-6149-4d1e-b42f-b34dc3ddef8f]
+description = "trinary 1122000120 is decimal 32091"
+
+[34be152d-38f3-4dcf-b5ab-9e14fe2f7161]
+description = "invalid trinary digits returns 0"
+
+[b57aa24d-3da2-4787-9429-5bc94d3112d6]
+description = "invalid word as input returns 0"
+
+[673c2057-5d89-483c-87fa-139da6927b90]
+description = "invalid numbers with letters as input returns 0"


### PR DESCRIPTION
We're in the process of re-opening the [Problem Specifications repo](https://github.com/exercism/problem-specifications), as discussed in [this issue](https://github.com/exercism/problem-specifications/issues/1674).
This PR adds `.meta/tests.toml` files for all exercises for which canonical data is defined in the Problem Specifications repo.
We'll now discuss _why_ we're making this change.
## Keeping track of implemented tests
While most of the changes to the Problem Specifications repo are specific to that repo, there is one track-specific change:
> If a track implements an exercise for which test data exists, the exercise _must_ contain a `.meta/tests.toml` file.
The goal of the `tests.toml` file is to keep track of which tests are implemented by the exercise.
Tests in this file are identified by their UUID and each test has a boolean value that indicates if it is implemented by that exercise.
A `tests.toml` file for a track's `two-fer` exercise looks like this:
```toml
[canonical-tests]
# no name given
"19709124-b82e-4e86-a722-9e5c5ebf3952" = true
# a name given
"3451eebd-123f-4256-b667-7b109affce32" = true
# another name given
"653611c6-be9f-4935-ab42-978e25fe9a10" = false
```
In this case, the track has chosen to implement two of the three available tests.
If a track uses a _test generator_ to generate an exercise's test suite, it _must_ use the contents of the `tests.toml` file to determine which tests to include in the generated test suite.
## Tooling
To make it easy to keep the `tests.toml` up to date, tracks can use the [`canonical_data_syncer` application](https://github.com/exercism/canonical-data-syncer).
This application is a small, standalone binary that will compare the tests specified in the `tests.toml` files against the tests that are defined in the exercise's canonical data.
It then interactively gives the maintainer the option to include or exclude test cases that are currently missing, updating the `tests.toml` file accordingly.
To use the canonical data syncer tool, tracks should copying the [`fetch-canonical_data_syncer`](https://github.com/exercism/canonical-data-syncer/blob/master/scripts/fetch-canonical_data_syncer) and/or [`fetch-canonical_data_syncer.ps1`](https://github.com/exercism/canonical-data-syncer/blob/master/scripts/fetch-canonical_data_syncer.ps1) scripts into their repository.
Then, running either of these scripts will download the latest version of the tool to the track's `bin` directory.
The tool can be run using `./bin/canonical_data_syncer` or `.\bin\canonical_data_syncer.exe`, depending on your operating system.
## Changes
In this PR, we're adding `meta/tests.toml` files for all the exercises for which canonical data is defined.
We've initially marked all tests as _included_, which means that we'll assume that your track has implemented those tests.
If there isn't anything obviously wrong with the PR, I would suggest to merge this PR first, and then later on update the `meta/tests.toml` files according to your track's actual implementation.
