### PR TITLE
[v3] Update Markdown files to latest spec

### DIFF
--- a/docs/ABOUT.md
+++ b/docs/ABOUT.md
@@ -1,3 +1,5 @@
+# About
+
 MIPS is a reduced instruction set computer (RISC) instruction set architecture, currently used mostly in video game consoles and routers. It is also a popular architecture in introductory courses and textbooks on computer architecture, due to its simplicity relative to x86 and ARM. Here we use the 32-bit instruction set; a 64-bit instruction set also exists.
 
 This track involves programming in MIPS assembly language, assembled and run on a cross-platform simulator.

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -1,1 +1,3 @@
+# Installation
+
 For these problems, we use the popular MIPS simulator [MARS](http://courses.missouristate.edu/KenVollmar/mars/). Download the MARS jar archive from the MARS website and place it somewhere easily accessible. Also install the Java SDK if you do not have it already.

--- a/docs/LEARNING.md
+++ b/docs/LEARNING.md
@@ -1,3 +1,5 @@
+# Learning
+
 MIPS is a simple assembly language. If you have done some assembly language programming before, you may be able to get started with just [a reference card](http://www.cburch.com/cs/330/reading/mips-ref.pdf).
 
 If you are entirely new to assembly language programming, consider working through the first half of Berkeley's “Great Ideas in Computer Architecture” course CS61C. [Video lectures are available on YouTube](https://www.youtube.com/watch?v=gJJeUFyuvvg&list=PL-XXv-cvA_iCl2-D-FS5mk0jFF6cYSJs_) and slides, labs, and homework assignments are available on [the course website](http://inst.eecs.berkeley.edu/~cs61c/sp15/). The book [_Computer Organization and Design_](https://smile.amazon.com/Computer-Organization-Design-Fifth-Architecture/dp/0124077269/) is also a commonly used introductory architecture book, which uses MIPS and covers the syntax in chapter 2.

--- a/docs/RESOURCES.md
+++ b/docs/RESOURCES.md
@@ -1,3 +1,5 @@
+# Resources
+
 
 * [MIPS Green Sheet](https://inst.eecs.berkeley.edu/~cs61c/resources/MIPS_Green_Sheet.pdf)
 * [cburch reference card](http://www.cburch.com/cs/330/reading/mips-ref.pdf)

--- a/docs/TESTS.md
+++ b/docs/TESTS.md
@@ -1,3 +1,5 @@
+# Tests
+
 To run the tests, assemble and run the test runner file for a given exercise either via the MARS simulator GUI, or on the command line. To run on the command line,
 specify first the runner file and then your implementation, like so:
 


### PR DESCRIPTION
We've defined a [specification for Markdown files](https://github.com/exercism/docs/blob/main/contributing/standards/markdown.md) to be applied Exercism-wide. This standard includes, amongst others, the following two rules:

- All files must start start with a level-1 heading (`# Some heading text`)
- No heading may decend a level greater than one below the previous (e.g. `## may only be followed by ###, not ####`)

This PR applies the above two rules to the Markdown documents in this repo. 

## Tracking

https://github.com/exercism/v3-launch/issues/17
