### PR TITLE
🤖 Add docs configuration

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -1,0 +1,32 @@
+{
+  "docs": [
+    {
+      "uuid": "5483415f-97be-4531-ae07-12a412c6944c",
+      "slug": "installation",
+      "path": "docs/INSTALLATION.md",
+      "title": "Installing MIPS Assembly locally",
+      "blurb": "Learn how to install MIPS Assembly locally to solve Exercism's exercises on your own machine"
+    },
+    {
+      "uuid": "8d7c6938-a51c-4594-bebe-434d972967f4",
+      "slug": "learning",
+      "path": "docs/LEARNING.md",
+      "title": "How to learn MIPS Assembly",
+      "blurb": "An overview of how to get started from scratch with MIPS Assembly"
+    },
+    {
+      "uuid": "18b2768b-ddca-4b43-8cca-13ade85e5fd1",
+      "slug": "tests",
+      "path": "docs/TESTS.md",
+      "title": "Testing on the MIPS Assembly track",
+      "blurb": "Learn how to test your MIPS Assembly exercises on Exercism"
+    },
+    {
+      "uuid": "56e2eb42-8e4f-4c5f-86f5-db67af7b5d12",
+      "slug": "resources",
+      "path": "docs/RESOURCES.md",
+      "title": "Useful MIPS Assembly resources",
+      "blurb": "A collection of useful resources to help you master MIPS Assembly"
+    }
+  ]
+}


### PR DESCRIPTION
To allow the v3 website to display the track's documentation, we're introducing a `docs/config.json` file, which contains information needed for rendering.

This commit adds the `docs/config.json` file. We will merge this PR shortly. For now, **please don't edit its contents**. We will follow up with a PR for CI, and with an issue linking you to the spec for this file once it's written up. Once that's all done, you will then be free to edit this config as normal 🙂

## Tracking

https://github.com/exercism/v3-launch/issues/25
