### PR TITLE
🤖 Simplify `hello-world` stub

### DIFF
--- a/exercises/practice/hello-world/example.mips
+++ b/exercises/practice/hello-world/example.mips
@@ -1,12 +1,5 @@
 .globl hello
 
-#
-# The classical introductory exercise. Just say "Hello, World!".
-#
-# Variables:
-#
-# $v0 - output, pointer to null-terminated string of chars "Hello, World!"
-
 .data
 
 msg: .asciiz "Hello, World!"

--- a/exercises/practice/hello-world/impl.mips
+++ b/exercises/practice/hello-world/impl.mips
@@ -1,0 +1,12 @@
+.globl hello
+
+.data
+
+msg: .asciiz "Goodbye, Mars!"
+
+.text
+
+hello:
+        la    $v0, msg
+
+        jr $ra


### PR DESCRIPTION
Simplify the `hello-world` exercise's stub. The goal of this is to make things easier for students to get started and to introduce as little syntax as possible.

See https://github.com/exercism/v3-launch/issues/46
