### PR TITLE
Report expected and actual values for failures

### DIFF
--- a/exercises/practice/binary/runner.mips
+++ b/exercises/practice/binary/runner.mips
@@ -23,6 +23,8 @@ ins:  .asciiz "0", "1", "10", "11", "100", "1001", "11010", "10001101000", "0000
 outs: .word     0,   1,   2,     3,    4,       9,      26,          1128,          31
 
 failmsg: .asciiz "failed for test input: "
+expectedmsg: .asciiz ". expected "
+tobemsg: .asciiz " to be "
 okmsg: .asciiz "all tests passed"
 
 
@@ -69,6 +71,22 @@ exit_fail:
 
         move    $a0, $s1                # print input that failed on
         li      $v0, 4
+        syscall
+
+        la      $a0, expectedmsg
+        li      $v0, 4
+        syscall
+
+        move    $a0, $v1                # print actual that failed on
+        li      $v0, 1
+        syscall
+
+        la      $a0, tobemsg
+        li      $v0, 4
+        syscall
+
+        move    $a0, $s4                # print expected value that failed on
+        li      $v0, 1
         syscall
 
         li      $a0, 1                  # set error code to 1

--- a/exercises/practice/leap/runner.mips
+++ b/exercises/practice/leap/runner.mips
@@ -21,6 +21,8 @@ ins:  .word 1996, 1997, 1998, 1900, 1800, 2400, 2000  # input years
 outs: .word    1,    0,    0,    0,    0,    1,    1  # expected result
 
 failmsg: .asciiz "failed for test input: "
+expectedmsg: .asciiz ". expected "
+tobemsg: .asciiz " to be "
 okmsg: .asciiz "all tests passed"
 
 
@@ -60,6 +62,22 @@ exit_fail:
 
         move    $a0, $s3                # set arg of syscall to input that failed the test
         li      $v0, 1                  # 1 is print int
+        syscall
+
+        la      $a0, expectedmsg
+        li      $v0, 4
+        syscall
+
+        move    $a0, $v1                # print actual that failed on
+        li      $v0, 1
+        syscall
+
+        la      $a0, tobemsg
+        li      $v0, 4
+        syscall
+
+        move    $a0, $s4                # print expected value that failed on
+        li      $v0, 1
         syscall
 
         li      $a0, 1                  # set exit code to 1

--- a/exercises/practice/nth-prime/runner.mips
+++ b/exercises/practice/nth-prime/runner.mips
@@ -23,6 +23,8 @@ ins:  .word     1,  2,  4,  7,   10,  47,   50,   57,   100,  101
 outs: .word		2,  3,  7,  17,  29,  211,  229,  269,  541,  547
 
 failmsg: .asciiz "failed for test input: "
+expectedmsg: .asciiz ". expected "
+tobemsg: .asciiz " to be "
 okmsg: .asciiz "all tests passed"
 
 
@@ -62,6 +64,22 @@ exit_fail:
         syscall
 
         lw      $a0, ($s1)              # print input that failed on
+        li      $v0, 1
+        syscall
+
+        la      $a0, expectedmsg
+        li      $v0, 4
+        syscall
+
+        move    $a0, $v1                # print actual that failed on
+        li      $v0, 1
+        syscall
+
+        la      $a0, tobemsg
+        li      $v0, 4
+        syscall
+
+        move    $a0, $s4                # print expected value that failed on
         li      $v0, 1
         syscall
 

--- a/exercises/practice/square-root/runner.mips
+++ b/exercises/practice/square-root/runner.mips
@@ -23,6 +23,8 @@ ins:  .word     1,  4,  25,  81,  196,  65025
 outs: .word     1,  2,  5,  9,  14,  255
 
 failmsg: .asciiz "failed for test input: "
+expectedmsg: .asciiz ". expected "
+tobemsg: .asciiz " to be "
 okmsg: .asciiz "all tests passed"
 
 
@@ -62,6 +64,22 @@ exit_fail:
         syscall
 
         lw      $a0, ($s1)              # print input that failed on
+        li      $v0, 1
+        syscall
+
+        la      $a0, expectedmsg
+        li      $v0, 4
+        syscall
+
+        move    $a0, $v1                # print actual that failed on
+        li      $v0, 1
+        syscall
+
+        la      $a0, tobemsg
+        li      $v0, 4
+        syscall
+
+        move    $a0, $s4                # print expected value that failed on
         li      $v0, 1
         syscall
 

--- a/exercises/practice/triangle/runner.mips
+++ b/exercises/practice/triangle/runner.mips
@@ -28,6 +28,8 @@ cs:   .word 2, 10, 4, 4, 4, 7, 5, 12, 2, 2, 3, 0
 outs: .word 2,  2, 1, 1, 1, 1, 0,  0, 0, 3, 3, 3
 
 failmsg: .asciiz "failed for test input: "
+expectedmsg: .asciiz ". expected "
+tobemsg: .asciiz " to be "
 okmsg: .asciiz "all tests passed"
 comma: .asciiz ", "
 
@@ -90,6 +92,22 @@ exit_fail:
 
         lw      $a0, 0($s3)             # set arg of syscall to input that failed the test
         li      $v0, 1                  # 1 is print int
+        syscall
+
+        la      $a0, expectedmsg
+        li      $v0, 4
+        syscall
+
+        move    $a0, $v1                # print actual that failed on
+        li      $v0, 1
+        syscall
+
+        la      $a0, tobemsg
+        li      $v0, 4
+        syscall
+
+        move    $a0, $s5                # print expected value that failed on
+        li      $v0, 1
         syscall
 
         li      $a0, 1                  # set exit code to 1

--- a/exercises/practice/trinary/runner.mips
+++ b/exercises/practice/trinary/runner.mips
@@ -23,6 +23,8 @@ ins:  .asciiz "0", "1", "10", "102101", "22222", "10000"
 outs: .word     0,   1,    3,      307,    242,       81
 
 failmsg: .asciiz "failed for test input: "
+expectedmsg: .asciiz ". expected "
+tobemsg: .asciiz " to be "
 okmsg: .asciiz "all tests passed"
 
 
@@ -69,6 +71,22 @@ exit_fail:
 
         move    $a0, $s1                # print input that failed on
         li      $v0, 4
+        syscall
+
+        la      $a0, expectedmsg
+        li      $v0, 4
+        syscall
+
+        move    $a0, $v1                # print actual that failed on
+        li      $v0, 1
+        syscall
+
+        la      $a0, tobemsg
+        li      $v0, 4
+        syscall
+
+        move    $a0, $s4                # print expected value that failed on
+        li      $v0, 1
         syscall
 
         li      $a0, 1                  # set error code to 1


### PR DESCRIPTION
For six exercises, we were previously only reporting the input that failed, not the expected and actual output.