### PR TITLE
grains: use `$v1` instead of `$10` as output register for the high word 

### DIFF
--- a/exercises/practice/grains/.docs/instructions.append.md
+++ b/exercises/practice/grains/.docs/instructions.append.md
@@ -6,5 +6,5 @@
 | -------- | --------- | ------- | -------------------------------- |
 | `$a0`    | input     | integer | square number in the range 1..64 |
 | `$v0`    | output    | integer | low 32 bits of output            |
-| `$10`    | output    | integer | high 32 bits of output           |
+| `$v1`    | output    | integer | high 32 bits of output           |
 | `$t0-9`  | temporary | any     | for temporary storage            |

--- a/exercises/practice/grains/impl.mips
+++ b/exercises/practice/grains/impl.mips
@@ -2,7 +2,7 @@
 # | -------- | --------- | ------- | -------------------------------- |
 # | `$a0`    | input     | integer | square number in the range 1..64 |
 # | `$v0`    | output    | integer | low 32 bits of output            |
-# | `$10`    | output    | integer | high 32 bits of output           |
+# | `$v1`    | output    | integer | high 32 bits of output           |
 # | `$t0-9`  | temporary | any     | for temporary storage            |
 
 .globl square


### PR DESCRIPTION
The **grains** exercise instructions suggest using the `$10` register to store the high word of the output, but the test runner expects it in `$v1`.