### PR TITLE
isbn-verifier, hamming: Fix handling of empty test string

### DIFF
--- a/exercises/practice/hamming/runner.mips
+++ b/exercises/practice/hamming/runner.mips
@@ -41,17 +41,13 @@ run_test:
         lw      $s5, 0($s3)             # read expected output from memory
         bne     $v1, $s5, exit_fail     # if expected doesn't match actual, jump to fail
 
-scan:
+input_scan:
+        lb      $s4, 0($s1)             # load byte
         addi    $s1, $s1, 1             # move input address one byte forward
         addi    $s2, $s2, 1
-        lb      $s4, 0($s1)             # load byte
-        beq     $s4, $zero, done_scan   # if char null, break loop
-        j       scan                    # loop
+        bne     $s4, $zero, input_scan  # until char null, continue loop
 
 done_scan:
-        addi    $s1, $s1, 1             # move input address one byte past null
-        addi    $s2, $s2, 1
-
         addi    $s3, $s3, 4             # move to next word in output
         sub     $s0, $s0, 1             # decrement num of tests left to run
         bgt     $s0, $zero, run_test    # if more than zero tests to run, jump to run_test

--- a/exercises/practice/isbn-verifier/runner.mips
+++ b/exercises/practice/isbn-verifier/runner.mips
@@ -75,18 +75,13 @@ run_test:
         lw      $s4, 0($s2)             # read expected output from memory
         bne     $v1, $s4, exit_fail     # if expected doesn't match actual, jump to exit_fail
 
-scan:
-        lb      $s3, 0($s1)             # Load byte at current address
-        beq     $s3,  $zero, post_scan  # if it's already null, jump: we've reached the end
-
-        addi    $s1, $s1, 1             # move input address on byte forward
-        lb      $s3, 0($s1)             # load byte
-        j       scan                    # loop
-
-post_scan:
+input_scan:
+        lb      $s3, 0($s1)
         addi    $s1, $s1, 1             # move input address on byte past null
+        bne     $s3, $zero, input_scan  # until char null, continue loop
 
-        addi    $s2, $s2, 4             # move to next word in output
+done_scan:
+        addi $s2, $s2, 4                # move to next word in output
         sub     $s0, $s0, 1             # decrement num of tests left to run
         bgt     $s0, $zero, run_test    # if more than zero tests to run, jump to run_test
 

--- a/exercises/practice/isbn-verifier/runner.mips
+++ b/exercises/practice/isbn-verifier/runner.mips
@@ -76,10 +76,14 @@ run_test:
         bne     $v1, $s4, exit_fail     # if expected doesn't match actual, jump to exit_fail
 
 scan:
+        lb      $s3, 0($s1)             # Load byte at current address
+        beq     $s3,  $zero, post_scan  # if it's already null, jump: we've reached the end
+
         addi    $s1, $s1, 1             # move input address on byte forward
         lb      $s3, 0($s1)             # load byte
-        bne     $s3, $zero, scan        # until char null, continue loop
+        j       scan                    # loop
 
+post_scan:
         addi    $s1, $s1, 1             # move input address on byte past null
 
         addi    $s2, $s2, 4             # move to next word in output

--- a/exercises/practice/isbn-verifier/runner.mips
+++ b/exercises/practice/isbn-verifier/runner.mips
@@ -81,7 +81,7 @@ input_scan:
         bne     $s3, $zero, input_scan  # until char null, continue loop
 
 done_scan:
-        addi $s2, $s2, 4                # move to next word in output
+        addi    $s2, $s2, 4             # move to next word in output
         sub     $s0, $s0, 1             # decrement num of tests left to run
         bgt     $s0, $zero, run_test    # if more than zero tests to run, jump to run_test
 


### PR DESCRIPTION
One of the test strings in runner.mips is the empty string, which should be refused as invalid. This test works correctly.

However, in `scan` after running the test, the runner accidentally skips past the *next* test by adding to the address before checking if the byte is null already (in the manner of a do...while loop). It should instead check if the byte is null at the top, and only proceed if it's not (in the manner of a while loop).

The consequence of this bug is that the test runner skips the "134456729" test string directly after "" and instead reads one past the `ins` array. It quickly finds an invalid test string there in the first word so everything seems to be going correctly. With this fix, that string is actually tested and we no longer read past the array.