### PR TITLE
Add configlet-sync github workflow

### DIFF
--- a/.github/configlet-sync-issue.md
+++ b/.github/configlet-sync-issue.md
@@ -1,0 +1,12 @@
+---
+title: Out of sync practice exercises
+---
+
+Out of sync practice exercises have been detected:
+
+Command: `configlet sync --tests --docs --metadata --filepaths`
+
+Output:
+```
+{{ env.SYNC_OUTPUT }}
+```

--- a/.github/workflows/configlet-sync.yml
+++ b/.github/workflows/configlet-sync.yml
@@ -1,0 +1,42 @@
+name: Configlet Sync
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 0 1 * *'
+
+jobs:
+  configlet:
+    if: github.repository_owner == 'exercism' # Stops this job from running on forks
+    timeout-minutes: 30
+    runs-on: ubuntu-24.04
+
+    steps:
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.0.0
+
+      - name: Fetch configlet
+        uses: exercism/github-actions/configlet-ci@main
+        # GITHUB_TOKEN is not set when we run the fetch script, because we're in
+        # a composite action. Set GH_TOKEN so that `gh release download` can
+        # make authenticated requests (it fails otherwise).
+        env:
+          GH_TOKEN: ${{ github.token }}
+
+      - name: Configlet Sync
+        id: sync
+        shell: bash {0}
+        run: |
+          echo "SYNC_OUTPUT<<EOF" >> $GITHUB_ENV
+          configlet sync --tests --docs --metadata --filepaths >> $GITHUB_ENV
+          exit_code=$?
+          echo "EOF" >> $GITHUB_ENV
+          exit $exit_code
+
+      - name: Create issue
+        if: ${{ failure() }}
+        uses: JasonEtco/create-an-issue@1b14a70e4d8dc185e5cc76d3bec9eab20257b2c5 # v2.9.2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          filename: .github/configlet-sync-issue.md
+          update_existing: true


### PR DESCRIPTION
This workflow was first implemented in the Common Lisp track, and is also used by the Emacs Lisp track.