### PR TITLE
fix: update macOs workflow

### DIFF
--- a/.github/workflows/exercise-tests.yml
+++ b/.github/workflows/exercise-tests.yml
@@ -19,7 +19,7 @@ jobs:
         os:
           - ubuntu-22.04
           - windows-2022
-          - macOS-12
+          - macOS-14
 
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332


### PR DESCRIPTION
GitHub dropped macOS-12 support. Workflow needs updating to 14.

See: https://forum.exercism.org/t/github-actions-runner-breaking-changes-announced/12612